### PR TITLE
TASK #48 : videos 디렉토리 없으면 생성 가능하도록 수정

### DIFF
--- a/Server/socket.js
+++ b/Server/socket.js
@@ -65,6 +65,14 @@ module.exports = (server, app) =>{
             // 데이터 수신중
             console.log(`Downloaded... ${(count / total * 100.0).toFixed(2)}%`);
 
+            // public/videos 디렉토리에 접근 가능한지 판단 (해당 디렉토리가 있는지)
+            try {
+              await fs.promises.access(path.join(__dirname, 'public', 'videos'))
+            } catch (error) {
+              console.log(error.message);
+              await fs.promises.mkdir(path.join(__dirname, 'public', 'videos'), {recursive : true}); // 디렉토리 없으면 생성
+            }
+
             // 버퍼 용량 문제로 인해 즉시 인코딩 후 덮어쓰기 함
             const decodedFile = Buffer.from(videoData.data, 'base64');
             await fs.promises.appendFile(filePath, decodedFile);


### PR DESCRIPTION
- 기존 코드에선 videos 디렉토리가 없으면 소켓 통신 시 에러가 발생하여 videos 디렉토리를 생성하여 처리했습니다.
- videos 디렉토리가 없어도 에러를 발생시키지 않고 videos 디렉토리를 생성하도록 코드를 수정했습니다.